### PR TITLE
Replace lodash for lodash.get

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     ]
   },
   "dependencies": {
-    "lodash.get": "^4.4.2",
+    "lodash.get": "4.4.2",
     "xml2js": "0.4.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     ]
   },
   "dependencies": {
-    "lodash": "4.13.1",
+    "lodash.get": "^4.4.2",
     "xml2js": "0.4.16"
   }
 }

--- a/src/cep-promise.js
+++ b/src/cep-promise.js
@@ -2,7 +2,7 @@
 
 import https from 'https'
 import xml2js from 'xml2js'
-import _get from 'lodash/get'
+import _get from 'lodash.get'
 
 const CEP_SIZE = 8
 


### PR DESCRIPTION
Don't use the full lodash module. When you do that you load the full module (almost 2MB) in memory and than import just the part you want.
When this happen you have a lot of bytes unused in memory.

With this change, the only thing in memory is the part that you use and its dependences.