### PR TITLE
Normalizar erros para sempre ser uma array de objetos

### DIFF
--- a/src/cep-promise.js
+++ b/src/cep-promise.js
@@ -20,7 +20,7 @@ export default function (cepRawValue) {
           return errorHandler(error)
         }))
       })
-      .catch((err) => reject(errorHandler(err)))
+      .catch((err) => reject( [errorHandler(err)] ))
 
     function validateInputType (cepRawValue) {
       let cepTypeOf = typeof cepRawValue

--- a/test/e2e/cep-promise.spec.js
+++ b/test/e2e/cep-promise.spec.js
@@ -67,7 +67,7 @@ describe('cep-promise (E2E)', () => {
 
   describe('when invoked with an invalid "123456789" cep', () => {
     it('should reject with "type_error"', () => {
-      return expect(cep('123456789')).to.be.rejected.and.to.eventually.deep.equal({
+      return expect(cep('123456789')).to.be.rejected.and.to.eventually.contain({
         type: 'type_error',
         message: 'CEP deve conter exatamente 8 caracteres',
         service: undefined

--- a/test/unit/cep-promise.spec.js
+++ b/test/unit/cep-promise.spec.js
@@ -26,7 +26,7 @@ describe('cep-promise (unit)', () => {
 
   describe('when invoked without arguments', () => {
     it('should reject with "type_error"', () => {
-      return expect(cep()).to.be.rejected.and.to.eventually.deep.equal({
+      return expect(cep()).to.be.rejected.and.to.eventually.contain({
         type: 'type_error',
         message: 'Você deve chamar o construtor utilizando uma String ou Number',
         service: undefined
@@ -36,7 +36,7 @@ describe('cep-promise (unit)', () => {
 
   describe('when invoked with an Array', () => {
     it('should reject with "type_error"', () => {
-      return expect(cep([1, 2, 3])).to.be.rejected.and.to.eventually.deep.equal({
+      expect(cep([1, 2, 3])).to.be.rejected.and.to.eventually.contain({
         type: 'type_error',
         message: 'Você deve chamar o construtor utilizando uma String ou Number',
         service: undefined
@@ -46,7 +46,7 @@ describe('cep-promise (unit)', () => {
 
   describe('when invoked with an Object', () => {
     it('should reject with "type_error"', () => {
-      return expect(cep({ nintendo: true, ps: false, xbox: false })).to.be.rejected.and.to.eventually.deep.equal({
+      return expect(cep({ nintendo: true, ps: false, xbox: false })).to.be.rejected.and.to.eventually.contain({
         type: 'type_error',
         message: 'Você deve chamar o construtor utilizando uma String ou Number',
         service: undefined
@@ -56,7 +56,7 @@ describe('cep-promise (unit)', () => {
 
   describe('when invoked with an Function', () => {
     it('should reject with "type_error"', () => {
-      return expect(cep(function zelda () { return 'link' })).to.be.rejected.and.to.eventually.deep.equal({
+      return expect(cep(function zelda () { return 'link' })).to.be.rejected.and.to.eventually.contain({
         type: 'type_error',
         message: 'Você deve chamar o construtor utilizando uma String ou Number',
         service: undefined


### PR DESCRIPTION
Esse PR normaliza o output de erros para ser sempre uma array de objetos.

Razões: https://github.com/filipedeschamps/cep-promise/issues/37#issuecomment-252024584