### PR TITLE
Fixed error handling so now throw real errors instead of objects

### DIFF
--- a/src/utils/custom-errors.js
+++ b/src/utils/custom-errors.js
@@ -1,0 +1,8 @@
+module.exports = class AggregateError extends Error {
+  constructor (errors) {
+    super('Aggregate error object, access errors via this.errors')
+    this.stack = (new Error()).stack;
+    this.name = this.constructor.name
+    this.errors = errors
+  }
+};

--- a/test/e2e/cep-promise.spec.js
+++ b/test/e2e/cep-promise.spec.js
@@ -35,43 +35,53 @@ describe('cep-promise (E2E)', () => {
 
   describe('when invoked with an inexistent "99999999" cep', () => {
     it('should reject with "range_error"', () => {
-      return expect(cep('99999999')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base dos Correios',
-          service: 'correios'
-        })
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base do ViaCEP',
-          service: 'viacep'
+      return cep('99999999')
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.include({
+            type: 'range_error',
+            message: 'CEP não encontrado na base dos Correios',
+            service: 'correios'
+          })
+          .include({
+            type: 'range_error',
+            message: 'CEP não encontrado na base do ViaCEP',
+            service: 'viacep'
+          })
         })
     })
   })
 
   describe('when invoked with an inexistend "1" cep', () => {
     it('should reject with "range_error"', () => {
-      return expect(cep('1')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base dos Correios',
-          service: 'correios'
-        })
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base do ViaCEP',
-          service: 'viacep'
+      return cep('1')
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.include({
+            type: 'range_error',
+            message: 'CEP não encontrado na base dos Correios',
+            service: 'correios'
+          })
+          .include({
+            type: 'range_error',
+            message: 'CEP não encontrado na base do ViaCEP',
+            service: 'viacep'
+          })
         })
     })
   })
 
   describe('when invoked with an invalid "123456789" cep', () => {
     it('should reject with "type_error"', () => {
-      return expect(cep('123456789')).to.be.rejected.and.to.eventually.contain({
-        type: 'type_error',
-        message: 'CEP deve conter exatamente 8 caracteres',
-        service: 'cep-promise'
-      })
+      return cep('123456789')
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.contains({
+            type: 'type_error',
+            message: 'CEP deve conter exatamente 8 caracteres',
+            service: 'cep-promise'
+          })
+        })
     })
   })
 })

--- a/test/unit/cep-promise.spec.js
+++ b/test/unit/cep-promise.spec.js
@@ -33,41 +33,57 @@ describe('cep-promise (unit)', () => {
 
   describe('when invoked without arguments', () => {
     it('should reject with "type_error"', () => {
-      return expect(cep()).to.be.rejected.and.to.eventually.contain({
-        type: 'type_error',
-        message: 'Você deve chamar o construtor utilizando uma String ou Number',
-        service: 'cep-promise'
-      })
+      return cep()
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.contain({
+            type: 'type_error',
+            message: 'Você deve chamar o construtor utilizando uma String ou Number',
+            service: 'cep-promise'
+          })
+        })
     })
   })
 
   describe('when invoked with an Array', () => {
     it('should reject with "type_error"', () => {
-      expect(cep([1, 2, 3])).to.be.rejected.and.to.eventually.contain({
-        type: 'type_error',
-        message: 'Você deve chamar o construtor utilizando uma String ou Number',
-        service: 'cep-promise'
-      })
+      return cep([1, 2, 3])
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.contain({
+            type: 'type_error',
+            message: 'Você deve chamar o construtor utilizando uma String ou Number',
+            service: 'cep-promise'
+          })
+        })
     })
   })
 
   describe('when invoked with an Object', () => {
     it('should reject with "type_error"', () => {
-      return expect(cep({ nintendo: true, ps: false, xbox: false })).to.be.rejected.and.to.eventually.contain({
-        type: 'type_error',
-        message: 'Você deve chamar o construtor utilizando uma String ou Number',
-        service: 'cep-promise'
-      })
+      return cep({ nintendo: true, ps: false, xbox: false })
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.contains({
+            type: 'type_error',
+            message: 'Você deve chamar o construtor utilizando uma String ou Number',
+            service: 'cep-promise'
+          })
+        })
     })
   })
 
   describe('when invoked with an Function', () => {
     it('should reject with "type_error"', () => {
-      return expect(cep(function zelda () { return 'link' })).to.be.rejected.and.to.eventually.contain({
-        type: 'type_error',
-        message: 'Você deve chamar o construtor utilizando uma String ou Number',
-        service: 'cep-promise'
-      })
+      return cep(function zelda () { return 'link' })
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.contain({
+            type: 'type_error',
+            message: 'Você deve chamar o construtor utilizando uma String ou Number',
+            service: 'cep-promise'
+          })
+        })
     })
   })
 
@@ -111,17 +127,19 @@ describe('cep-promise (unit)', () => {
       nock('https://viacep.com.br')
         .get('/ws/99999999/json/')
         .replyWithFile(200, path.join(__dirname, '/fixtures/viacep-cep-99999999-error.json'))
-
-      return expect(cep('99999999')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base dos Correios',
-          service: 'correios'
-        })
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base do ViaCEP',
-          service: 'viacep'
+      return cep('99999999')
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.include({
+            type: 'range_error',
+            message: 'CEP não encontrado na base dos Correios',
+            service: 'correios'
+          })
+          .include({
+            type: 'range_error',
+            message: 'CEP não encontrado na base do ViaCEP',
+            service: 'viacep'
+          })
         })
     })
   })
@@ -131,12 +149,15 @@ describe('cep-promise (unit)', () => {
       nock('https://apps.correios.com.br')
         .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
         .replyWithFile(500, path.join(__dirname, '/fixtures/response-cep-invalid-format.xml'))
-
-      return expect(cep('123456789')).to.be.rejected.and.to.eventually.deep.include({
-        type: 'type_error',
-        message: 'CEP deve conter exatamente 8 caracteres',
-        service: 'cep-promise'
-      })
+      return cep('123456789')
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.include({
+            type: 'type_error',
+            message: 'CEP deve conter exatamente 8 caracteres',
+            service: 'cep-promise'
+          })
+        })
     })
   })
 
@@ -201,16 +222,22 @@ describe('cep-promise (unit)', () => {
       nock('https://viacep.com.br')
         .get('/ws/05010000/json/')
         .reply(400, '<h2>Bad Request (400)</h2>')
-      return expect(cep('05010000')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'error',
-          message: 'Erro ao se conectar com o serviço dos Correios',
-          service: 'correios'
-        })
-        .include({
-          type: 'error',
-          message: 'Erro ao se conectar com o serviço ViaCEP',
-          service: 'viacep'
+      return cep('05010000')
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.include({
+            type: 'system',
+            message: 'Erro ao se conectar com o serviço dos Correios',
+            service: 'correios',
+            name: 'FetchError',
+            errno: undefined,
+            code: undefined
+          })
+          .include({
+            type: 'error',
+            message: 'Erro ao se conectar com o serviço ViaCEP',
+            service: 'viacep'
+          })
         })
     })
   })
@@ -222,17 +249,19 @@ describe('cep-promise (unit)', () => {
       nock('https://viacep.com.br')
         .get('/ws/05010000/json/')
         .reply(400, '<h2>Bad Request (400)</h2>')
-
-      return expect(cep('05010000')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'type_error',
-          message: 'Não foi possível interpretar o XML de resposta',
-          service: 'correios'
-        })
-        .include({
-          type: 'error',
-          message: 'Erro ao se conectar com o serviço ViaCEP',
-          service: 'viacep'
+      return cep('05010000')
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.include({
+            type: 'type_error',
+            message: 'Não foi possível interpretar o XML de resposta',
+            service: 'correios'
+          })
+          .include({
+            type: 'error',
+            message: 'Erro ao se conectar com o serviço ViaCEP',
+            service: 'viacep'
+          })
         })
     })
   })
@@ -245,17 +274,25 @@ describe('cep-promise (unit)', () => {
       nock('https://viacep.com.br')
         .get('/ws/05010000/json/')
         .replyWithError('getaddrinfo ENOTFOUND apps.correios.com.br apps.correios.com.br:443')
-
-      return expect(cep('05010000')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'error',
-          message: 'Erro ao se conectar com o serviço dos Correios',
-          service: 'correios'
-        })
-        .include({
-          type: 'error',
-          message: 'Erro ao se conectar com o serviço ViaCEP',
-          service: 'viacep'
+      return cep('05010000')
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.include({
+            type: 'system',
+            message: 'Erro ao se conectar com o serviço dos Correios',
+            service: 'correios',
+            name: 'FetchError',
+            errno: undefined,
+            code: undefined
+          })
+          .include({
+            type: 'system',
+            message: 'Erro ao se conectar com o serviço ViaCEP',
+            service: 'viacep',
+            name: 'FetchError',
+            errno: undefined,
+            code: undefined
+          })
         })
     })
   })
@@ -268,12 +305,15 @@ describe('cep-promise (unit)', () => {
       nock('https://viacep.com.br')
         .get('/ws/05010000/json/')
         .replyWithError('getaddrinfo ENOTFOUND viacep.com.br viacep.com.br:443')
-
-      return expect(cep('05010000')).to.be.rejected.and.to.eventually.deep.include({
-        type: 'range_error',
-        message: 'CEP deve conter exatamente 8 caracteres',
-        service: 'correios'
-      })
+      return cep('05010000')
+        .catch((err) => {
+          expect(err).to.be.an('error')
+          expect(err.errors).to.include({
+            type: 'range_error',
+            message: 'CEP deve conter exatamente 8 caracteres',
+            service: 'correios'
+          })
+        })
     })
   })
 


### PR DESCRIPTION
Ideia de tratamento de erros reais, sem objetos contendo erros.

- Criado custom error.
- Definido como o error é usado.
- Refatorado os testes.


Essa é uma ideia inicial, se pensar em resolver de outra forma não tem problema nenhum! 😁 

PR referente a issue #51 