### PR TITLE
feat(error): change public error interface to use Custom Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@
 </p>
 
 <p align="center">
-  Busca por CEP integrado diretamente aos serviços dos Correios e ViaCEP
+  Busca por CEP integrado diretamente aos serviços dos Correios e ViaCEP (Node.js e Browser)
 </p>
 
 ## Features
 
  * Sempre atualizado em tempo-real por se conectar diretamente aos serviços dos Correios ou ViaCEP
  * Possui alta disponibilidade por usar serviços como fallback
- * Sempre retorna a resposta mais rápida por usar concorrência
- * Sem limites de uso (rate limit) conhecidos
+ * Sempre retorna a resposta mais rápida por fazer as consultas de forma concorrente
+ * Sem limites de uso (rate limits) conhecidos
  * Interface de Promise extremamente simples
  * Suporte ao Node.js `0.10.x`, `0.12.x`, `4.x`, `5.x`, `6.x` e `@stable`
  * 100% de code coverage com testes unitários e E2E
@@ -50,10 +50,10 @@ $ npm install --save cep-promise
 Por ser multifornecedor, a biblioteca irá resolver a Promise com o fornecedor que mais rápido lhe responder.
 
 ``` js
-import cep from 'cep-promise';
+import cep from 'cep-promise'
 
 cep('05010000')
-  .then(console.log);
+  .then(console.log)
 
   // {
   //   "zipcode":  "05010000",
@@ -70,11 +70,11 @@ cep('05010000')
 Em muitos sistemas o CEP é utilizado erroneamente como um Inteiro (e com isto cortanto todos os zeros à esquerda). Caso este seja o seu caso, não há problema, pois a biblioteca irá preencher os caracteres faltantes na String, por exemplo:
 
 ``` js
-import cep from 'cep-promise';
+import cep from 'cep-promise'
 
 // enviando sem ter um zero à esquerda do CEP "05010000"
 cep(5010000)
-  .then(console.log);
+  .then(console.log)
 
   // {
   //   "zipcode":  "05010000",
@@ -87,45 +87,46 @@ cep(5010000)
 
 ### Quando o CEP não é encontrado
 
-Por ser multifornecedor, a biblioteca irá rejeitar a Promise apenas quando tiver a resposta negativa de todos os fornecedores.
+Neste caso será retornado um `"service_error"` e por ser multifornecedor, a biblioteca irá rejeitar a Promise apenas quando tiver a resposta negativa de todos os fornecedores.
 
 ``` js
-import cep from 'cep-promise';
+import cep from 'cep-promise'
 
 cep('99999999')
-  .catch(console.log);
+  .catch(console.log)
 
-  // [
-  //   {
-  //     "type": "range_error",
-  //     "message": "CEP não encontrado na base dos Correios",
-  //     "service": 'correios'
-  //   },
-  //   {
-  //     "type": "range_error",
-  //     "message": "CEP inválido",
-  //     "service": "viacep"
-  //   }
-  // ]
+  // {
+  //     message: 'Todos os serviços de CEP retornaram erro.',
+  //     type: 'service_error',
+  //     errors: [{
+  //       message: 'CEP NAO ENCONTRADO',
+  //       service: 'correios'
+  //     }, {
+  //       message: 'CEP não encontrado na base do ViaCEP.',
+  //       service: 'viacep'
+  //     }]
+  // }
+
 ```
 
 ### Quando o CEP possui um formato inválido
 
-Neste caso a biblioteca irá rejeitar imediatamente a Promise, sem chegar a consultar nenhum fornecedor.
+Neste caso será retornado um `"validation_error"` e a biblioteca irá rejeitar imediatamente a Promise, sem chegar a consultar nenhum fornecedor.
 
 ``` js
-import cep from 'cep-promise';
+import cep from 'cep-promise'
 
 cep('123456789123456789')
-  .catch(console.log);
+  .catch(console.log)
 
-  // [
-  //   {
-  //     "type": "type_error",
-  //     "message": "CEP deve conter exatamente 8 caracteres",
-  //     "service": undefined
-  //   }
-  // ]
+  // {
+  //     message: 'CEP deve conter exatamente 8 caracteres.',
+  //     type: 'validation_error',
+  //     errors: [{
+  //       message: 'CEP informado possui mais do que 8 caracteres.',
+  //       service: 'cep_validation'
+  //     }]
+  // }
 ```
 
 ## Contribuidores

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "browserify": "13.1.0",
     "chai": "3.5.0",
     "chai-as-promised": "5.3.0",
+    "chai-subset": "1.3.0",
     "mocha": "3.0.1",
     "nock": "8.0.0",
     "standard": "7.1.2",
@@ -52,7 +53,11 @@
     ]
   },
   "dependencies": {
+    "babel-cli": "6.16.0",
+    "babel-core": "6.17.0",
+    "babel-preset-es2015": "6.16.0",
     "bluebird": "3.4.6",
+    "chai-as-promised": "6.0.0",
     "isomorphic-fetch": "2.2.1",
     "lodash.get": "4.4.2",
     "xml2js": "0.4.16"

--- a/src/errors/cep-promise.js
+++ b/src/errors/cep-promise.js
@@ -1,0 +1,12 @@
+function CepPromiseError (options) {
+  options = options || {}
+  this.name = 'CepPromiseError'
+  this.message = options.message
+  this.type = options.type
+  this.errors = options.errors
+}
+
+CepPromiseError.prototype = Object.create(Error.prototype)
+CepPromiseError.prototype.constructor = CepPromiseError
+
+export default CepPromiseError

--- a/src/errors/service.js
+++ b/src/errors/service.js
@@ -1,0 +1,12 @@
+function ServiceError (options) {
+  options = options || {}
+  this.name = 'ServiceError'
+  this.message = options.message
+  this.service = options.service
+}
+
+ServiceError.prototype = Object.create(Error.prototype)
+ServiceError.prototype.constructor = Error
+
+export default ServiceError
+

--- a/src/services/correios.js
+++ b/src/services/correios.js
@@ -3,84 +3,93 @@
 import xml2js from 'xml2js'
 import _get from 'lodash.get'
 import fetch from 'isomorphic-fetch'
+import ServiceError from '../errors/service.js'
 
 const parseXMLString = xml2js.parseString
 
-const CEP_SIZE = 8
-
 function fetchCorreiosService (cepWithLeftPad) {
-  const url = 'https://apps.correios.com.br/SigepMasterJPA/AtendeClienteService/AtendeCliente'
-  const options = {
-    method: 'POST',
-    body: '<?xml version="1.0"?>\n<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cli="http://cliente.bean.master.sigep.bsb.correios.com.br/">\n  <soapenv:Header />\n  <soapenv:Body>\n    <cli:consultaCEP>\n      <cep>' + cepWithLeftPad + '</cep>\n    </cli:consultaCEP>\n  </soapenv:Body>\n</soapenv:Envelope>',
-    mode: 'no-cors',
-    headers: {
-      'Content-Type': 'text/xml; charset=utf-8',
-      'cache-control': 'no-cache'
-    }
-  }
-  return fetch(url, options)
-    .then(parseResponse)
-    .catch(throwError)
-}
 
-function parseResponse (response) {
-  if (response.ok) {
-    return response.text()
-      .then(parseXML)
-      .then(extractValuesFromSuccessResponse)
-  }
-
-  return response.text()
-    .then(parseXML)
-    .then(translateErrorMessage)
-    .then(throwRangeError)
-}
-
-function parseXML (xmlString) {
   return new Promise((resolve, reject) => {
-    parseXMLString(xmlString, (err, responseObject) => {
-      if (!err) {
-        resolve(responseObject)
+    const url = 'https://apps.correios.com.br/SigepMasterJPA/AtendeClienteService/AtendeCliente'
+    const options = {
+      method: 'POST',
+      body: '<?xml version="1.0"?>\n<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cli="http://cliente.bean.master.sigep.bsb.correios.com.br/">\n  <soapenv:Header />\n  <soapenv:Body>\n    <cli:consultaCEP>\n      <cep>' + cepWithLeftPad + '</cep>\n    </cli:consultaCEP>\n  </soapenv:Body>\n</soapenv:Envelope>',
+      mode: 'no-cors',
+      headers: {
+        'Content-Type': 'text/xml; charset=utf-8',
+        'cache-control': 'no-cache'
       }
-      throw new TypeError('Não foi possível interpretar o XML de resposta')
-    })
+    }
+    return fetch(url, options)
+      .then(analyzeAndParseResponse)
+      .then(resolvePromise)
+      .catch(rejectWithServiceError)
+
+
+    function analyzeAndParseResponse (response) {
+      if (response.ok) {
+        return response.text()
+          .then(parseXML)
+          .then(extractValuesFromSuccessResponse)
+      }
+
+      return response.text()
+        .then(parseXML)
+        .then(extractErrorMessage)
+        .then(throwError)
+    }
+
+    function parseXML (xmlString) {
+      return new Promise((resolve, reject) => {
+        parseXMLString(xmlString, (err, responseObject) => {
+          if (!err) {
+            resolve(responseObject)
+          }
+
+          throw new Error('Não foi possível interpretar o XML de resposta.')
+        })
+      })
+    }
+
+    function extractErrorMessage (xmlObject) {
+      return _get(xmlObject, 'soap:Envelope.soap:Body[0].soap:Fault[0].faultstring[0]')
+    }
+
+    function throwError (translatedErrorMessage) {
+      throw new Error(translatedErrorMessage)
+    }
+
+    function extractValuesFromSuccessResponse (xmlObject) {
+      let addressValues = _get(xmlObject, 'soap:Envelope.soap:Body[0].ns2:consultaCEPResponse[0].return[0]')
+
+      return {
+        cep: _get(addressValues, 'cep[0]'),
+        state: _get(addressValues, 'uf[0]'),
+        city: _get(addressValues, 'cidade[0]'),
+        neighborhood: _get(addressValues, 'bairro[0]'),
+        street: _get(addressValues, 'end[0]')
+      }
+    }
+
+    function resolvePromise (cepObject) {
+      resolve(cepObject)
+    }
+
+    function rejectWithServiceError (error) {
+      const serviceError = new ServiceError({
+        message: error.message,
+        service: 'correios'
+      })
+
+      if (error.name === 'FetchError') {
+        serviceError.message = 'Erro ao se conectar com o serviço dos Correios.'
+      }
+
+      reject(serviceError)
+    }
+
   })
 }
 
-function translateErrorMessage (xmlObject) {
-  let errorMessageFromCorreios = _get(xmlObject, 'soap:Envelope.soap:Body[0].soap:Fault[0].faultstring[0]')
-
-  const dictionary = {
-    'CEP NAO ENCONTRADO': 'CEP não encontrado na base dos Correios',
-    'BUSCA DEFINIDA COMO EXATA, 0 CEP DEVE TER 8 DIGITOS': 'CEP deve conter exatamente ' + CEP_SIZE + ' caracteres'
-  }
-
-  return dictionary[errorMessageFromCorreios] || errorMessageFromCorreios
-}
-
-function throwRangeError (translatedErrorMessage) {
-  throw new RangeError(translatedErrorMessage)
-}
-
-function extractValuesFromSuccessResponse (xmlObject) {
-  let addressValues = _get(xmlObject, 'soap:Envelope.soap:Body[0].ns2:consultaCEPResponse[0].return[0]')
-
-  return {
-    cep: _get(addressValues, 'cep[0]'),
-    state: _get(addressValues, 'uf[0]'),
-    city: _get(addressValues, 'cidade[0]'),
-    neighborhood: _get(addressValues, 'bairro[0]'),
-    street: _get(addressValues, 'end[0]')
-  }
-}
-
-function throwError (error) {
-  if (error.name === 'FetchError') {
-    error.message = 'Erro ao se conectar com o serviço dos Correios'
-  }
-
-  throw Object.assign(error, { service: 'correios' })
-}
 
 export default fetchCorreiosService

--- a/src/services/viacep.js
+++ b/src/services/viacep.js
@@ -1,46 +1,72 @@
 'use strict'
 
 import fetch from 'isomorphic-fetch'
+import ServiceError from '../errors/service.js'
 
 function fetchViaCepService (cepWithLeftPad) {
-  const url = 'https://viacep.com.br/ws/' + cepWithLeftPad + '/json/'
-  const options = {
-    method: 'GET',
-    uri: 'https://viacep.com.br/ws/' + cepWithLeftPad + '/json/',
-    mode: 'cors',
-    headers: {
-      'content-type': 'application/json;charset=utf-8'
-    }
-  }
 
-  return fetch(url, options)
-    .then(response => response.json())
-    .then(extractValuesFromParsedResponse)
-    .catch((err) => {
-      if (err instanceof RangeError) {
-        throw Object.assign(err, {
-          service: 'viacep'
-        })
+  return new Promise((resolve, reject) => {
+    const url = 'https://viacep.com.br/ws/' + cepWithLeftPad + '/json/'
+    const options = {
+      method: 'GET',
+      mode: 'cors',
+      headers: {
+        'content-type': 'application/json;charset=utf-8'
       }
-      throw Object.assign(err, {
-        message: 'Erro ao se conectar com o serviço ViaCEP',
+    }
+
+    return fetch(url, options)
+      .then(analyzeAndParseResponse)
+      .then(checkForViaCepError)
+      .then(extractCepValuesFromResponse)
+      .then(resolvePromise)
+      .catch(rejectWithServiceError)
+
+    function analyzeAndParseResponse (response) {
+      if (response.ok) {
+        return response.json()
+      }
+
+      throw Error('Erro ao se conectar com o serviço ViaCEP.')
+    }
+
+    function checkForViaCepError (responseObject) {
+      if (responseObject.erro === true) {
+        throw new Error('CEP não encontrado na base do ViaCEP.')
+      }
+
+      return responseObject
+    }
+
+    function extractCepValuesFromResponse (responseObject) {
+      return {
+        cep: responseObject.cep.replace('-', ''),
+        state: responseObject.uf,
+        city: responseObject.localidade,
+        neighborhood: responseObject.bairro,
+        street: responseObject.logradouro
+      }
+    }
+
+    function resolvePromise (cepObject) {
+      resolve(cepObject)
+    }
+
+    function rejectWithServiceError (error) {
+      const serviceError = new ServiceError({
+        message: error.message,
         service: 'viacep'
       })
-    })
-}
 
-function extractValuesFromParsedResponse (responseObject) {
-  if (responseObject.erro === true) {
-    throw new RangeError('CEP não encontrado na base do ViaCEP')
-  }
+      if (error.name === 'FetchError') {
+        serviceError.message = 'Erro ao se conectar com o serviço ViaCEP.'
+      }
 
-  return {
-    cep: responseObject.cep.replace('-', ''),
-    state: responseObject.uf,
-    city: responseObject.localidade,
-    neighborhood: responseObject.bairro,
-    street: responseObject.logradouro
-  }
+      reject(serviceError)
+    }
+
+  })
+
 }
 
 export default fetchViaCepService

--- a/test/e2e/cep-promise.spec.js
+++ b/test/e2e/cep-promise.spec.js
@@ -2,9 +2,13 @@
 
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
+import chaiSubset from 'chai-subset'
+
 import cep from '../../src/cep-promise.js'
+import CepPromiseError from '../../src/errors/cep-promise.js'
 
 chai.use(chaiAsPromised)
+chai.use(chaiSubset)
 
 let expect = chai.expect
 
@@ -33,45 +37,42 @@ describe('cep-promise (E2E)', () => {
     })
   })
 
-  describe('when invoked with an inexistent "99999999" cep', () => {
-    it('should reject with "range_error"', () => {
-      return expect(cep('99999999')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base dos Correios',
-          service: 'correios'
-        })
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base do ViaCEP',
-          service: 'viacep'
-        })
-    })
-  })
-
-  describe('when invoked with an inexistend "1" cep', () => {
-    it('should reject with "range_error"', () => {
-      return expect(cep('1')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base dos Correios',
-          service: 'correios'
-        })
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base do ViaCEP',
-          service: 'viacep'
+  describe('when invoked with an inexistent "99999999" CEP', () => {
+    it('should reject with "service_error"', () => {
+      return cep('99999999')
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'Todos os serviços de CEP retornaram erro.',
+              type: 'service_error',
+              errors: [{
+                message: 'CEP NAO ENCONTRADO',
+                service: 'correios'
+              }, {
+                message: 'CEP não encontrado na base do ViaCEP.',
+                service: 'viacep'
+              }]
+            })
         })
     })
   })
 
-  describe('when invoked with an invalid "123456789" cep', () => {
-    it('should reject with "type_error"', () => {
-      return expect(cep('123456789')).to.be.rejected.and.to.eventually.contain({
-        type: 'type_error',
-        message: 'CEP deve conter exatamente 8 caracteres',
-        service: 'cep-promise'
-      })
+  describe('when invoked with an invalid "123456789" CEP', () => {
+    it('should reject with "validation_error"', () => {
+      return cep('123456789')
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'CEP deve conter exatamente 8 caracteres.',
+              type: 'validation_error',
+              errors: [{
+                service: 'cep_validation',
+                message: 'CEP informado possui mais do que 8 caracteres.'
+              }]
+            })
+        })
     })
   })
 })

--- a/test/unit/cep-promise.spec.js
+++ b/test/unit/cep-promise.spec.js
@@ -2,18 +2,22 @@
 
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import cep from '../../src/cep-promise.js'
+import chaiSubset from 'chai-subset'
 import nock from 'nock'
 import path from 'path'
 
+import cep from '../../src/cep-promise.js'
+import CepPromiseError from '../../src/errors/cep-promise.js'
+
 chai.use(chaiAsPromised)
+chai.use(chaiSubset)
 
 let expect = chai.expect
 
 describe('cep-promise (unit)', () => {
   describe('when imported', () => {
     it('should return a Function', () => {
-      expect(cep).to.be.an('function')
+      expect(cep).to.be.a('function')
     })
   })
 
@@ -25,57 +29,94 @@ describe('cep-promise (unit)', () => {
       nock('https://viacep.com.br')
         .get('/ws/05010000/json/')
         .replyWithFile(200, path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json'))
-      const cepRequest = cep('05010000')
-      expect(cepRequest.then).to.be.a('function')
-      expect(cepRequest.catch).to.be.a('function')
+
+      const cepPromise = cep('05010000')
+      expect(cepPromise.then).to.be.a('function')
+      expect(cepPromise.catch).to.be.a('function')
     })
   })
 
   describe('when invoked without arguments', () => {
-    it('should reject with "type_error"', () => {
-      return expect(cep()).to.be.rejected.and.to.eventually.contain({
-        type: 'type_error',
-        message: 'Você deve chamar o construtor utilizando uma String ou Number',
-        service: 'cep-promise'
-      })
+    it('should reject with "validation_error"', () => {
+      return cep()
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'Erro ao inicializar a instância do CepPromise.',
+              type: 'validation_error',
+              errors: [{
+                message: 'Você deve chamar o construtor utilizando uma String ou Number.',
+                service: 'cep_validation'
+              }]
+            })
+        })
     })
   })
 
   describe('when invoked with an Array', () => {
-    it('should reject with "type_error"', () => {
-      expect(cep([1, 2, 3])).to.be.rejected.and.to.eventually.contain({
-        type: 'type_error',
-        message: 'Você deve chamar o construtor utilizando uma String ou Number',
-        service: 'cep-promise'
-      })
+    it('should reject with "validation_error"', () => {
+      return cep([1, 2, 3])
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'Erro ao inicializar a instância do CepPromise.',
+              type: 'validation_error',
+              errors: [{
+                message: 'Você deve chamar o construtor utilizando uma String ou Number.',
+                service: 'cep_validation'
+              }]
+            })
+        })
     })
   })
 
   describe('when invoked with an Object', () => {
-    it('should reject with "type_error"', () => {
-      return expect(cep({ nintendo: true, ps: false, xbox: false })).to.be.rejected.and.to.eventually.contain({
-        type: 'type_error',
-        message: 'Você deve chamar o construtor utilizando uma String ou Number',
-        service: 'cep-promise'
-      })
+    it('should reject with "validation_error"', () => {
+      return cep({ nintendo: true, ps: false, xbox: false })
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'Erro ao inicializar a instância do CepPromise.',
+              type: 'validation_error',
+              errors: [{
+                message: 'Você deve chamar o construtor utilizando uma String ou Number.',
+                service: 'cep_validation'
+              }]
+            })
+        })
     })
   })
 
   describe('when invoked with an Function', () => {
-    it('should reject with "type_error"', () => {
-      return expect(cep(function zelda () { return 'link' })).to.be.rejected.and.to.eventually.contain({
-        type: 'type_error',
-        message: 'Você deve chamar o construtor utilizando uma String ou Number',
-        service: 'cep-promise'
-      })
+    it('should reject with "validation_error"', () => {
+      return cep(function zelda () { return 'link' })
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'Erro ao inicializar a instância do CepPromise.',
+              type: 'validation_error',
+              errors: [{
+                message: 'Você deve chamar o construtor utilizando uma String ou Number.',
+                service: 'cep_validation'
+              }]
+            })
+        })
     })
   })
 
-  describe('when invoked with a valid "05010000" string', () => {
+
+  describe('when invoked with a valid "05010000" String', () => {
     it('should fulfill with correct address', () => {
       nock('https://apps.correios.com.br')
         .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
         .replyWithFile(200, path.join(__dirname, '/fixtures/response-cep-05010000-found.xml'))
+      nock('https://viacep.com.br')
+        .get('/ws/05010000/json/')
+        .replyWithFile(200, path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json'))
 
       return expect(cep('05010000')).to.eventually.deep.equal({
         cep: '05010000',
@@ -87,11 +128,14 @@ describe('cep-promise (unit)', () => {
     })
   })
 
-  describe('when invoked with a valid 5010000 number', () => {
+  describe('when invoked with a valid 5010000 Number', () => {
     it('should fulfill with correct address', () => {
       nock('https://apps.correios.com.br')
         .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
         .replyWithFile(200, path.join(__dirname, '/fixtures/response-cep-05010000-found.xml'))
+      nock('https://viacep.com.br')
+        .get('/ws/05010000/json/')
+        .replyWithFile(200, path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json'))
 
       return expect(cep(5010000)).to.eventually.deep.equal({
         cep: '05010000',
@@ -103,51 +147,15 @@ describe('cep-promise (unit)', () => {
     })
   })
 
-  describe('when invoked with an inexistend "99999999" cep', () => {
-    it('should reject with "range_error"', () => {
-      nock('https://apps.correios.com.br')
-        .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
-        .replyWithFile(500, path.join(__dirname, '/fixtures/response-cep-not-found.xml'))
-      nock('https://viacep.com.br')
-        .get('/ws/99999999/json/')
-        .replyWithFile(200, path.join(__dirname, '/fixtures/viacep-cep-99999999-error.json'))
-
-      return expect(cep('99999999')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base dos Correios',
-          service: 'correios'
-        })
-        .include({
-          type: 'range_error',
-          message: 'CEP não encontrado na base do ViaCEP',
-          service: 'viacep'
-        })
-    })
-  })
-
-  describe('when invoked with an invalid "123456789" cep', () => {
-    it('should reject with "type_error"', () => {
-      nock('https://apps.correios.com.br')
-        .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
-        .replyWithFile(500, path.join(__dirname, '/fixtures/response-cep-invalid-format.xml'))
-
-      return expect(cep('123456789')).to.be.rejected.and.to.eventually.deep.include({
-        type: 'type_error',
-        message: 'CEP deve conter exatamente 8 caracteres',
-        service: 'cep-promise'
-      })
-    })
-  })
-
   describe('when request returns with error but with an unkown XML schema and then succeed to the failover service', () => {
-    it('should reject with "error"', () => {
+    it('should fulfill with correct address', () => {
       nock('https://apps.correios.com.br')
         .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
         .replyWithFile(500, path.join(__dirname, '/fixtures/response-unknown-format.xml'))
       nock('https://viacep.com.br')
         .get('/ws/05010000/json/')
         .replyWithFile(200, path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json'))
+
       return expect(cep('5010000')).to.eventually.deep.equal({
         cep: '05010000',
         state: 'SP',
@@ -166,6 +174,7 @@ describe('cep-promise (unit)', () => {
       nock('https://viacep.com.br')
         .get('/ws/05010000/json/')
         .replyWithFile(200, path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json'))
+
       return expect(cep('5010000')).to.eventually.deep.equal({
         cep: '05010000',
         state: 'SP',
@@ -176,7 +185,7 @@ describe('cep-promise (unit)', () => {
     })
   })
 
-  describe('when http request to correios fails and then succeed to the failover service', () => {
+  describe('when http request to Correios fails and then succeed to the failover service', () => {
     it('should fulfill with correct address', () => {
       nock('https://apps.correios.com.br')
         .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
@@ -184,6 +193,7 @@ describe('cep-promise (unit)', () => {
       nock('https://viacep.com.br')
         .get('/ws/05010000/json/')
         .replyWithFile(200, path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json'))
+
       return expect(cep('5010000')).to.eventually.deep.equal({
         cep: '05010000',
         state: 'SP',
@@ -193,29 +203,84 @@ describe('cep-promise (unit)', () => {
       })
     })
   })
+
+  describe('when invoked with an inexistend "99999999" CEP', () => {
+    it('should reject with "service_error"', () => {
+      nock('https://apps.correios.com.br')
+        .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
+        .replyWithFile(500, path.join(__dirname, '/fixtures/response-cep-not-found.xml'))
+      nock('https://viacep.com.br')
+        .get('/ws/99999999/json/')
+        .replyWithFile(200, path.join(__dirname, '/fixtures/viacep-cep-99999999-error.json'))
+
+
+      return cep('99999999')
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'Todos os serviços de CEP retornaram erro.',
+              type: 'service_error',
+              errors: [{
+                message: 'CEP NAO ENCONTRADO',
+                service: 'correios'
+              }, {
+                message: 'CEP não encontrado na base do ViaCEP.',
+                service: 'viacep'
+              }]
+            })
+        })
+    })
+  })
+
+  describe('when invoked with an invalid "123456789" CEP', () => {
+    it('should reject with "validation_error"', () => {
+      return cep('123456789')
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'CEP deve conter exatamente 8 caracteres.',
+              type: 'validation_error',
+              errors: [{
+                service: 'cep_validation',
+                message: 'CEP informado possui mais do que 8 caracteres.'
+              }]
+            })
+        })
+    })
+  })
+
   describe('when http request fails both for primary and secondary service with bad response', () => {
-    it('should reject with "error"', () => {
+    it('should reject with "service_error"', () => {
       nock('https://apps.correios.com.br')
         .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
         .replyWithError('getaddrinfo ENOTFOUND apps.correios.com.br apps.correios.com.br:443')
       nock('https://viacep.com.br')
         .get('/ws/05010000/json/')
         .reply(400, '<h2>Bad Request (400)</h2>')
-      return expect(cep('05010000')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'error',
-          message: 'Erro ao se conectar com o serviço dos Correios',
-          service: 'correios'
-        })
-        .include({
-          type: 'error',
-          message: 'Erro ao se conectar com o serviço ViaCEP',
-          service: 'viacep'
+
+      return cep('05010000')
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'Todos os serviços de CEP retornaram erro.',
+              type: 'service_error',
+              errors: [{
+                message: 'Erro ao se conectar com o serviço dos Correios.',
+                service: 'correios'
+              }, {
+                message: 'Erro ao se conectar com o serviço ViaCEP.',
+                service: 'viacep'
+              }]
+            })
         })
     })
   })
+
   describe('when http request has unformated xml and secondary service fails', () => {
-    it('should reject with "error"', () => {
+    it('should reject with "service_error"', () => {
       nock('https://apps.correios.com.br')
         .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
         .replyWithFile(200, path.join(__dirname, '/fixtures/response-bad-xml.xml'))
@@ -223,22 +288,27 @@ describe('cep-promise (unit)', () => {
         .get('/ws/05010000/json/')
         .reply(400, '<h2>Bad Request (400)</h2>')
 
-      return expect(cep('05010000')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'type_error',
-          message: 'Não foi possível interpretar o XML de resposta',
-          service: 'correios'
-        })
-        .include({
-          type: 'error',
-          message: 'Erro ao se conectar com o serviço ViaCEP',
-          service: 'viacep'
+      return cep('05010000')
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'Todos os serviços de CEP retornaram erro.',
+              type: 'service_error',
+              errors: [{
+                message: 'Não foi possível interpretar o XML de resposta.',
+                service: 'correios'
+              }, {
+                message: 'Erro ao se conectar com o serviço ViaCEP.',
+                service: 'viacep'
+              }]
+            })
         })
     })
   })
 
   describe('when http request fails both for primary and secondary service with error', () => {
-    it('should reject with "error"', () => {
+    it('should reject with "service_error"', () => {
       nock('https://apps.correios.com.br')
         .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
         .replyWithError('getaddrinfo ENOTFOUND apps.correios.com.br apps.correios.com.br:443')
@@ -246,34 +316,22 @@ describe('cep-promise (unit)', () => {
         .get('/ws/05010000/json/')
         .replyWithError('getaddrinfo ENOTFOUND apps.correios.com.br apps.correios.com.br:443')
 
-      return expect(cep('05010000')).to.be.rejected.and.to.eventually.deep
-        .include({
-          type: 'error',
-          message: 'Erro ao se conectar com o serviço dos Correios',
-          service: 'correios'
+      return cep('05010000')
+        .catch((error) => {
+          return expect(error)
+            .to.be.an.instanceOf(CepPromiseError)
+            .and.containSubset({
+              message: 'Todos os serviços de CEP retornaram erro.',
+              type: 'service_error',
+              errors: [{
+                message: 'Erro ao se conectar com o serviço dos Correios.',
+                service: 'correios'
+              }, {
+                message: 'Erro ao se conectar com o serviço ViaCEP.',
+                service: 'viacep'
+              }]
+            })
         })
-        .include({
-          type: 'error',
-          message: 'Erro ao se conectar com o serviço ViaCEP',
-          service: 'viacep'
-        })
-    })
-  })
-
-  describe("when http request fails to correios because it's length it is superior to 8", () => {
-    it('should reject with "error"', () => {
-      nock('https://apps.correios.com.br')
-        .post('/SigepMasterJPA/AtendeClienteService/AtendeCliente')
-        .replyWithFile(500, path.join(__dirname, '/fixtures/response-cep-invalid-format.xml'))
-      nock('https://viacep.com.br')
-        .get('/ws/05010000/json/')
-        .replyWithError('getaddrinfo ENOTFOUND viacep.com.br viacep.com.br:443')
-
-      return expect(cep('05010000')).to.be.rejected.and.to.eventually.deep.include({
-        type: 'range_error',
-        message: 'CEP deve conter exatamente 8 caracteres',
-        service: 'correios'
-      })
     })
   })
 


### PR DESCRIPTION
Proposta para alterar a interface de erro da biblioteca para a versão `2.0`

Em resumo foram criados dois Custom Errors:

1. `ServiceError`: que deve ser lançado pelos fornecedores de CEP
2. `CepPromiseError`: que deve ser lançado pela biblioteca

E no final das contas, o usuário vai ter que lidar com duas variações de erro (pelo campo `type`):

1. `validation_error`: quando o formato está errado
2. `service_error`: quando o formato está certo, mas o CEP não existe ou os serviços estão offline.

O formato do erro está mais flexível e pode ser expandindo sem causar uma breaking change:

```
 {
     message: 'Todos os serviços de CEP retornaram erro.',
     type: 'service_error',
     errors: [{
       message: 'CEP NAO ENCONTRADO',
       service: 'correios'
     }, {
       message: 'CEP não encontrado na base do ViaCEP.',
       service: 'viacep'
     }]
 }
```

Outro ponto é que no detalhe dos erros (array `errors`) tentei deixar a mensagem original do fornecedor quando possível, pois o usuário pode conseguir debuggar melhor e ele tem uma descrição mais amigável na propriedade `message` principal.

Aproveitei também para refatorar grande parte do código para deixar os serviços mais normalizados entre sí, todos os testes e o README.