### PR TITLE
Conserta o suporte ao browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.3",
   "description": "Busca por CEP integrado diretamente aos serviços dos Correios e ViaCEP",
   "main": "dist/cep-promise.js",
-  "browser": "dist/cep-promise-browser.min.js",
   "scripts": {
     "test": "npm run coverage",
     "coverage": "babel-node node_modules/.bin/babel-istanbul cover _mocha -- --timeout 30000 test/**/*.spec.js",
@@ -14,9 +13,24 @@
     "lint-check": "standard",
     "lint-fix": "standard --fix",
     "build-node": "babel src --out-dir dist",
-    "build-web": "npm run build-node && browserify dist/cep-promise.js -s cep -o | uglifyjs > dist/cep-promise-browser.min.js",
+    "build-web": "browserify src/cep-promise.js -s cep -o | uglifyjs > dist/cep-promise-browser.min.js",
     "build": "npm run build-node && npm run build-web",
     "prepublish": "npm run build"
+  },
+  "browserify": {
+    "transform": [
+      [
+        "babelify",
+        {
+          "presets": [
+            "es2015"
+          ],
+          "plugins": [
+            "add-module-exports"
+          ]
+        }
+      ]
+    ]
   },
   "repository": {
     "type": "git",
@@ -35,6 +49,7 @@
     "babel-istanbul": "0.11.0",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-preset-es2015": "6.13.2",
+    "babelify": "7.3.0",
     "browserify": "13.1.0",
     "chai": "3.5.0",
     "chai-as-promised": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -53,11 +53,7 @@
     ]
   },
   "dependencies": {
-    "babel-cli": "6.16.0",
-    "babel-core": "6.17.0",
-    "babel-preset-es2015": "6.16.0",
     "bluebird": "3.4.6",
-    "chai-as-promised": "6.0.0",
     "isomorphic-fetch": "2.2.1",
     "lodash.get": "4.4.2",
     "xml2js": "0.4.16"


### PR DESCRIPTION
Desta forma fazemos o build diretamente do `src` e usando os transformers do jeito certo.

Arquivo não gziped por hora está `363K`.

![image](https://cloud.githubusercontent.com/assets/4248081/19642633/e6f94dc2-99c4-11e6-8c60-086cd131b482.png)
