### PR TITLE
feat(browser): use a mock Correios service only on browser build

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
       ]
     ]
   },
+  "browser": {
+    "./src/services/correios.js": "./src/services/correios-browser-mock.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/filipedeschamps/cep-promise.git"

--- a/src/services/correios-browser-mock.js
+++ b/src/services/correios-browser-mock.js
@@ -1,0 +1,26 @@
+'use strict'
+
+import ServiceError from '../errors/service.js'
+
+/*
+ * This is a mock service to be used when Browserify
+ * renders the distribution file. Correios service
+ * doesn't support CORS, so there's no reason to
+ * include the original file with it's (heavy)
+ * dependencies like "xml2js"
+ */
+
+function fetchCorreiosService (cepWithLeftPad) {
+
+  return new Promise((resolve, reject) => {
+    const serviceError = new ServiceError({
+      message: 'O serviço dos Correios não aceita requests via Browser (CORS).',
+      service: 'correios'
+    })
+
+    reject(serviceError)
+  })
+}
+
+
+export default fetchCorreiosService


### PR DESCRIPTION
Isso reduz o build do browser de `236K` para `16K` (sem gzip). Como o Correios não aceita CORS, não vale a pena incluir ele.

E como agora temos uma propagação legal de erros, basta rejeitar o serviço mock com um ServiceError 👍 

![image](https://cloud.githubusercontent.com/assets/4248081/19749941/f6914f7e-9bcb-11e6-8eeb-e6867524b627.png)
