### PR TITLE
Definition para TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+interface CEP {
+    cep:  string | number,
+    state:  string,
+    city:  string,
+    street:  string,
+    neighborhood:  string
+}
+
+export default function cep(cep: string | number): Promise<CEP>
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 interface CEP {
-    cep:  string | number,
+    cep:  string,
     state:  string,
     city:  string,
     street:  string,


### PR DESCRIPTION
Com essa definition o pacote poderá ser importado em um projeto TypeScript com `import { default as  cep }  from 'cep-promise'`.