### PR TITLE
Atualiza a versão da lib no Bower para a mesma do NPM

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cep-promise",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Busca por CEP integrado diretamente aos serviços dos Correios e ViaCEP",
   "main": "dist/cep-promise-browser.js",
   "authors": [


### PR DESCRIPTION
Esse PR tem como objetivo eliminar o _warning_ abaixo que foi pego ao executar `bower install cep-promise`.

![screen shot 2017-05-02 at 11 29 33](https://cloud.githubusercontent.com/assets/2177742/25622595/44a014f0-2f2b-11e7-88f3-a90e593542ce.png)

## TODO

- [x] Atualizar a versão em `bower.json`