### PR TITLE
chore(readme): replace Build with Downloads/month badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">CEP Promise</h1>
 
 <p align="center">
-  <a href="https://travis-ci.org/filipedeschamps/cep-promise">
-    <img src="https://travis-ci.org/filipedeschamps/cep-promise.svg?branch=master">
+  <a href="https://www.npmjs.com/package/cep-promise">
+    <img src="https://img.shields.io/npm/dm/cep-promise.svg">
   </a>
   <a href="https://coveralls.io/github/filipedeschamps/cep-promise?branch=master">
     <img src="https://coveralls.io/repos/github/filipedeschamps/cep-promise/badge.svg?branch=master">


### PR DESCRIPTION
O badge de build não adiciona muita informação, a master nunca vai estar quebrada ou ao menos não vai ser um badge que vai ter alguma influencia nisso.

Pessoas saberem quantos downloads por mês está sendo feito do módulo expõe uma credibilidade muito interessante.

O que acham?