### PR TITLE
Adicionando suporte ao uso da lib via CLI.

### DIFF
--- a/bin/cep-cli.js
+++ b/bin/cep-cli.js
@@ -1,0 +1,34 @@
+#! /usr/bin/env node
+const cep = require('../dist/cep-promise')
+const cepNumber = process.argv.splice(2, 1)[0]
+
+const pretify = (obj) => {
+  return Object.keys(obj)
+    .map(key => `${key}: ${obj[key]}`)
+    .join('\n')
+}
+
+const successfulLog = (result) => console.log(`
+✉️  😃  ✉️
+${pretify(result)}
+`)
+
+const failureLog = (result) => console.log(`
+❌  😰  ❌
+${pretify(result)}
+`)
+
+const noArgsProvided = () => console.log(`
+😔
+Não foi possível reconhecer os parametros de entrada.
+Tente novamente seguindo o exemplo:
+cep 29065250
+`)
+
+if (!cepNumber) {
+  noArgsProvided()
+} else {
+  cep(cepNumber)
+    .then(successfulLog)
+    .catch(failureLog)
+}

--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
     "isomorphic-fetch": "2.2.1",
     "lodash.get": "4.4.2",
     "xml2js": "0.4.17"
+  },
+  "bin": {
+    "cep": "bin/cep-cli.js"
   }
 }


### PR DESCRIPTION
Bora movimentar o projeto galeraaa!! 🎉 🚀 

O objetivo desse PR é implementar uma nova forma de interfacear e utilizar a lib, desta vez por meio do terminal digitando apenas `cep <cepNumber>`.

Para utilização da mesma basta instalar a lib no ambiente global `npm i -g cep-promise` e o comando cep estará disponível no terminal.

Objetivos:
- [x] Implementar arquivo chamado pelo comando
- [x] Implementar comando que invoca CLI
- [ ] Testar instalação global (Bloqueio até que a versão seja publicada para ser testada)
- [ ] Atualizar README para documentar novas funcionalidades