### PR TITLE
Adicionando instalação usando jsDelivr como CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@
 
 ### Instalação
 
+#### Browser usando CDN
+```
+<script src="https://cdn.jsdelivr.net/npm/cep-promise/dist/cep-promise-browser.min.js"></script>
+```
+
 #### NPM
 
 ```


### PR DESCRIPTION
Adicionando instalação via CDN para simplificar a entrada de novos usuários.

(Só pra manter no mínimo um PR ativo hahaha)