### PR TITLE
Atualiza o travis e o readme com versões atuais do node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "node"
+  - "8"
   - "7"
   - "6"
   - "5"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
  * Sempre retorna a resposta mais rápida por fazer as consultas de forma concorrente
  * Sem limites de uso (rate limits) conhecidos
  * Interface de Promise extremamente simples
- * Suporte ao Node.js `0.10.x`, `0.12.x`, `4.x`, `5.x`, `6.x` e `7.x`
+ * Suporte ao Node.js `0.10.x`, `0.12.x`, `4.x`, `5.x`, `6.x`, `7.x`, `8.x` e `9.x`
  * 100% de code coverage com testes unitários e E2E
  * Desenvolvido utilizando ES6
 


### PR DESCRIPTION
Ja que a build "node" no travis roda com a versão mais nova (9.x) achei que seria justo falar que damos suporte a ela e adicionei o `8` no travis ja que não é mais latest.