### PR TITLE
build(ignore): add files property to package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-src
-.travis.yml
-.codeclimate.yml
-.editorconfig
-.nvmrc
-test
-.DS_Store

--- a/package.json
+++ b/package.json
@@ -62,5 +62,9 @@
     "isomorphic-fetch": "2.2.1",
     "lodash.get": "4.4.2",
     "xml2js": "0.4.17"
-  }
+  },
+  "files": [
+    "dist",
+    "index.d.ts"
+  ]
 }


### PR DESCRIPTION
Ignorar arquivos não necessários para o uso do módulo. Hoje apesar de ser usado um npmignore [vários arquivos](https://unpkg.com/cep-promise@3.0.0/) que não precisam estar no npm estão sendo mandados para lá. Uma abordagem seria adicionar ele no npmignore, no entanto é mais fácil dizer o que deve ir para o npm em vez do que não deve ir. Ai entra a [propriedade `files` do `package.json`](https://docs.npmjs.com/files/package.json#files) nela você adiciona o que não deve ser ignorado, todo o resto é ignorado por padrão, facilitando a configuração e futuras mudanças.