### PR TITLE
Correção dos typings - segundo round

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,10 @@ require('/dist/cep-promise-browser.min.js')
   }
 ```
 
-#### Angular 2
+#### Angular 2/4/5
 
 ``` ts
-import * as cep from 'cep-promise'
+import cep from 'cep-promise'
 
 cep('05010000')
   .then(console.log)

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,12 +7,5 @@ declare module 'cep-promise' {
     neighborhood: string
   }
 
-  // this workarround is because this : https://github.com/Microsoft/TypeScript/issues/5073
-  namespace cep {}
-
-  function cep( cep: string | number ): Promise<CEP>
-
-  export = cep
+  export default function cep(cep: string | number): Promise<CEP>
 }
-
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cep-promise",
-  "version": "2.0.8",
+  "version": "3.0.0",
   "description": "Busca por CEP integrado diretamente aos serviços dos Correios e ViaCEP",
   "main": "dist/cep-promise.js",
   "module": "dist/cep-promise-esm.js",


### PR DESCRIPTION
No angular 5 parece que corrigiram a questão do typings que tinha que fazer um `workaround`
no typings para aceitar a default function sem usar  '{cep as default}' que ficava deselegante no typescript.

Acredito que houve correção no typescript que acabou resolvendo o problema.

Agora podemos declarar o cep igual é feito no js.

Essa pr corrige o problema mencionado em #112 