### PR TITLE
fix(dependency): lock `isomorphic-unfetch` to version `2.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ]
   },
   "dependencies": {
-    "isomorphic-unfetch": "^2.0.0"
+    "isomorphic-unfetch": "2.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Closes https://github.com/filipedeschamps/cep-promise/issues/124

Em resumo, o `isomorphic-unfetch` tava declarado com `^` e pegando automaticamente o último release do móduo `2.1.1` e por algum motivo começou a gerar uma incompatibilidade com versões do Node.js abaixo de 7.

Fixando a versão do módulo para `2.0.0` volta a passar a `master`. Mais para frente precisamos entender o que foi esse bump de versão, porque eu não consigo encontrar as releases notes.