### PR TITLE
Adicionado comando para instalação via Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ $ npm install --save cep-promise
 ```
 $ bower install --save cep-promise
 ```
+#### yarn
+
+```
+$ yarn add cep-promise
+```
 
 #### Angular 2
 


### PR DESCRIPTION
O pacote já está na base do Yarn em https://yarn.pm/cep-promise. Só adicionei o comando ao README.md.