### PR TITLE
feature/keep-alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ cep('05010000')
   // }
 ```
 
+### Realizando uma consulta avançada
+Para passar configurações como Proxy e Agent:
+
+
+``` js
+import cep from 'cep-promise'
+import https from 'https'
+
+const agent = new https.Agent({ keepAlive: true })
+const proxyURL = 'socks5://127.0.0.1:1950'
+
+const configurations = { agent, proxyURL }
+cep('05010000', configurations)
+  .then(console.log)
+
+  // {
+  //   "cep":  "05010000",
+  //   "state":  "SP",
+  //   "city":  "São Paulo",
+  //   "street":  "Rua Caiubí",
+  //   "neighborhood":  "Perdizes",
+  // }
+```
+
 
 ### Você também poderá passar o CEP como Inteiro
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ export default [
     input,
     plugins: [
       replace({
-        'node-fetch': 'unfetch',
+        'node-fetch': 'unfetch'
       })
     ].concat(defaultPlugins, [
       resolve({
@@ -43,4 +43,3 @@ export default [
     }
   }
 ]
-

--- a/src/cep-promise.js
+++ b/src/cep-promise.js
@@ -12,7 +12,7 @@ export default function (cepRawValue, configurations = {}) {
     .then(cepRawValue => {
       configurations.providers = configurations.providers ? configurations.providers : []
       validateProviders(configurations.providers)
-      
+
       return cepRawValue
     })
     .then(removeSpecialCharacters)
@@ -26,7 +26,7 @@ export default function (cepRawValue, configurations = {}) {
 }
 
 function validateProviders (providers) {
-  let availableProviders = ['brasilapi', 'correios', 'viacep', 'widenet']
+  const availableProviders = ['brasilapi', 'correios', 'viacep', 'widenet']
 
   if (!Array.isArray(providers)) {
     throw new CepPromiseError({
@@ -35,7 +35,7 @@ function validateProviders (providers) {
       errors: [
         {
           message:
-            `O parâmetro providers deve ser uma lista.`,
+            'O parâmetro providers deve ser uma lista.',
           service: 'providers_validation'
         }
       ]

--- a/src/cep-promise.js
+++ b/src/cep-promise.js
@@ -107,17 +107,19 @@ function validateInputLength (cepWithLeftPad) {
 }
 
 function fetchCepFromServices (cepWithLeftPad, configurations) {
-  let providersServices = getAvailableServices()
+  const providersServices = getAvailableServices()
 
-  if (configurations.providers.length === 0) {
+  const { providers: providersFromConfigurations, ...configurationsWithoutProviders } = configurations
+
+  if (providersFromConfigurations.length === 0) {
     return Promise.any(
-      Object.values(providersServices).map(provider => provider(cepWithLeftPad))
+      Object.values(providersServices).map(provider => provider(cepWithLeftPad, configurationsWithoutProviders))
     )
   }
 
   return Promise.any(
-    configurations.providers.map(provider => {
-      return providersServices[provider](cepWithLeftPad)
+    providersFromConfigurations.map(provider => {
+      return providersServices[provider](cepWithLeftPad, configurationsWithoutProviders)
     })
   )
 }

--- a/src/services/brasilapi.js
+++ b/src/services/brasilapi.js
@@ -3,14 +3,15 @@
 import fetch from 'node-fetch'
 import ServiceError from '../errors/service.js'
 
-export default function fetchBrasilAPIService (cepWithLeftPad) {
+export default function fetchBrasilAPIService (cepWithLeftPad, { agent = undefined }) {
   const url = `https://brasilapi.com.br/api/cep/v1/${cepWithLeftPad}`
   const options = {
     method: 'GET',
     mode: 'cors',
     headers: {
       'content-type': 'application/json;charset=utf-8'
-    }
+    },
+    agent
   }
 
   return fetch(url, options)
@@ -23,7 +24,7 @@ function parseResponse (response) {
   if (response.ok === false || response.status !== 200) {
     throw new Error('CEP não encontrado na base do BrasilAPI.')
   }
-  
+
   return response.json()
 }
 

--- a/src/services/correios.js
+++ b/src/services/correios.js
@@ -72,7 +72,7 @@ function extractValuesFromSuccessResponse (xmlObject) {
     city: xmlObject.cidade,
     neighborhood: xmlObject.bairro,
     street: xmlObject.end,
-    service: 'correios',
+    service: 'correios'
   }
 }
 

--- a/src/services/correios.js
+++ b/src/services/correios.js
@@ -3,7 +3,7 @@
 import fetch from 'node-fetch'
 import ServiceError from '../errors/service.js'
 
-export default function fetchCorreiosService (cepWithLeftPad, proxyURL = '') {
+export default function fetchCorreiosService (cepWithLeftPad, { proxyURL = '', agent = undefined }) {
   const url = `${proxyURL}https://apps.correios.com.br/SigepMasterJPA/AtendeClienteService/AtendeCliente`
   const options = {
     method: 'POST',
@@ -11,7 +11,8 @@ export default function fetchCorreiosService (cepWithLeftPad, proxyURL = '') {
     headers: {
       'Content-Type': 'text/xml;charset=UTF-8',
       'cache-control': 'no-cache'
-    }
+    },
+    agent
   }
 
   return fetch(url, options)

--- a/src/services/viacep.js
+++ b/src/services/viacep.js
@@ -44,7 +44,7 @@ function extractCepValuesFromResponse (responseObject) {
     city: responseObject.localidade,
     neighborhood: responseObject.bairro,
     street: responseObject.logradouro,
-    service: 'viacep',
+    service: 'viacep'
   }
 }
 

--- a/src/services/viacep.js
+++ b/src/services/viacep.js
@@ -3,7 +3,7 @@
 import fetch from 'node-fetch'
 import ServiceError from '../errors/service.js'
 
-export default function fetchViaCepService (cepWithLeftPad, proxyURL = '') {
+export default function fetchViaCepService (cepWithLeftPad, { proxyURL = '', agent = undefined }) {
   const url = `${proxyURL}https://viacep.com.br/ws/${cepWithLeftPad}/json/`
   const options = {
     method: 'GET',
@@ -11,7 +11,8 @@ export default function fetchViaCepService (cepWithLeftPad, proxyURL = '') {
     headers: {
       'content-type': 'application/json;charset=utf-8',
       'user-agent': ''
-    }
+    },
+    agent
   }
 
   return fetch(url, options)

--- a/src/services/widenet.js
+++ b/src/services/widenet.js
@@ -3,14 +3,15 @@
 import fetch from 'node-fetch'
 import ServiceError from '../errors/service.js'
 
-export default function fetchWideNetService (cepWithLeftPad, proxyURL = '') {
+export default function fetchWideNetService (cepWithLeftPad, { proxyURL = '', agent = undefined }) {
   const url = `${proxyURL}https://cep.widenet.host/busca-cep/api/cep/${cepWithLeftPad}.json`
   const options = {
     method: 'GET',
     mode: 'cors',
     headers: {
       'content-type': 'application/json;charset=utf-8'
-    }
+    },
+    agent
   }
 
   return fetch(url, options)

--- a/test/e2e/cep-promise.spec.js
+++ b/test/e2e/cep-promise.spec.js
@@ -11,24 +11,25 @@ import CepPromiseError from '../../src/errors/cep-promise.js'
 chai.use(chaiAsPromised)
 chai.use(chaiSubset)
 
-let expect = chai.expect
+const expect = chai.expect
 
 describe('[e2e] cep-promise', () => {
   before(() => {
     nock.enableNetConnect()
   })
-  
+
   describe('when invoked with a valid "05010000" string', () => {
     it('should fulfill with correct address', () => cep('05010000')
-        .then(address => {
-          expect(address).to.deep.equal({
-            cep: '05010000',
-            state: 'SP',
-            city: 'São Paulo',
-            neighborhood: 'Perdizes',
-            street: 'Rua Caiubi',
-            service: address.service
-        })})
+      .then(address => {
+        expect(address).to.deep.equal({
+          cep: '05010000',
+          state: 'SP',
+          city: 'São Paulo',
+          neighborhood: 'Perdizes',
+          street: 'Rua Caiubi',
+          service: address.service
+        })
+      })
     )
   })
 

--- a/test/e2e/cep-promise.spec.js
+++ b/test/e2e/cep-promise.spec.js
@@ -4,6 +4,7 @@ import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import chaiSubset from 'chai-subset'
 import nock from 'nock'
+import https from 'https'
 
 import cep from '../../src/cep-promise.js'
 import CepPromiseError from '../../src/errors/cep-promise.js'
@@ -38,13 +39,30 @@ describe('[e2e] cep-promise', () => {
       const address = await cep(5010000)
 
       expect(address).to.deep.equal({
-            cep: '05010000',
-            state: 'SP',
-            city: 'São Paulo',
-            neighborhood: 'Perdizes',
-            street: 'Rua Caiubi',
-            service: address.service
-          })
+        cep: '05010000',
+        state: 'SP',
+        city: 'São Paulo',
+        neighborhood: 'Perdizes',
+        street: 'Rua Caiubi',
+        service: address.service
+      })
+    })
+  })
+
+  describe('when invoked with a valid 05010000 number and agent', () => {
+    it('should fulfill with correct address', async () => {
+      const agent = new https.Agent({ keepAlive: true })
+
+      const address = await cep(5010000, { agent })
+
+      expect(address).to.deep.equal({
+        cep: '05010000',
+        state: 'SP',
+        city: 'São Paulo',
+        neighborhood: 'Perdizes',
+        street: 'Rua Caiubi',
+        service: address.service
+      })
     })
   })
 


### PR DESCRIPTION
### Motivação
Dependendo da quantidade de requisições feitas, perde-se muito tempo fazendo o [handshaking](https://en.wikipedia.org/wiki/Handshaking) e isso pode ser facilmente resolvido com o cabeçalho [keep-alive.](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Headers/Keep-Alive) A implementação foi baseada na [issue#423 do node-fetch](https://github.com/node-fetch/node-fetch/issues/423).

### Implementação
Quando estava implementando fiquei na dúvida se era uma boa escolha colocar isso como default ou uma configuração da lib, então para evitar que essa modificação cause algum problema para os demais desenvolvedores preferi passar como uma configuração. E com isso aproveitei para possibilitar que as proxies também sejam passadas como configuração aos serviços.

Por fim, agora caso queiramos passar qualquer tipo de configuração aos serviços não precisaremos mais (talvez / espero eu hahaha) modificar a interface.

### Observações
- Não sabia como poderia testar se a requisição voltou com keep-alive na resposta sem afetar a interface do cep-promise
- Um dos testes falhou, mas creio que não está relacionado com as mudanças que fiz
- Fiz algumas correções de code-style
- Se forçar code-style for algo muito importante, é preciso modificar o `lint-fix` para algo assim:
  ```json
   "lint-fix": "standard '*.js' 'src/**/*.js' 'test/**/*.js' --fix",
  ```

